### PR TITLE
complete PerformanceReport initialisation removed some console.logs

### DIFF
--- a/backend/src/models/SocialPerformance.js
+++ b/backend/src/models/SocialPerformance.js
@@ -57,8 +57,8 @@ class SocialPerformance {
 module.exports = { SocialPerformance };
 
 
-const tmp = new SocialPerformance();
-for(const entry of tmp){
-    console.log(entry)
-}
+// const tmp = new SocialPerformance();
+// for(const entry of tmp){
+//     console.log(entry)
+// }
 

--- a/backend/src/services/bonus-computation-service.js
+++ b/backend/src/services/bonus-computation-service.js
@@ -45,7 +45,7 @@ function defaultCalculationSales({ rating, quantity }) {
  */
 function socialCalculation(socialPerformance, socialCal = defaultCalculationSocial) {
     let socialBonus = {}, total = 0;
-    console.log(socialPerformance)
+    // console.log(socialPerformance)
     if (socialPerformance) {
         for (const value of socialPerformance) {
             // Calculate the bonus for each social criterion
@@ -119,36 +119,36 @@ module.exports = {
     bonusComputation
 };
 
-// Creating an instance of SocialPerformance using default data
-const defaultSocialPerformance = {
-    leadershipCompetence: { actual: 5, target: 10 },
-    opennessToEmployee: { actual: 8, target: 10 },
-    socialBehaviourToEmployee: { actual: 9, target: 10 },
-    attitudeTowardsClients: { actual: 7, target: 10 },
-    communicationSkills: { actual: 6, target: 10 },
-    integrityToCompany: { actual: 10, target: 10 }
-};
-
-// Constructing an instance of SocialPerformance with default data
-const socialPerformance = new SocialPerformance(defaultSocialPerformance);
-
-// Creating an instance of SalesPerformance using sales data
-const salesDetails = {
-    "HooverClean": [
-        { clientName: "Germania GmbH", quantity: 10, rating: 3 },
-        { clientName: "Dirk Müller GmbH", quantity: 25, rating: 3 }
-    ],
-    "HooverGo": [
-        { clientName: "Telekom AG", quantity: 20, rating: 1 }
-    ]
-};
-
-// Constructing an instance of SalesPerformance with sales data
-const salesPerformance = new SalesPerformance(salesDetails);
-
-// Performing the bonus calculation
-const bonus = bonusComputation(socialPerformance, salesPerformance);
-
-// Printing the bonus calculation result
-console.log("Bonus Calculation Result: ", bonus);
+// // Creating an instance of SocialPerformance using default data
+// const defaultSocialPerformance = {
+//     leadershipCompetence: { actual: 5, target: 10 },
+//     opennessToEmployee: { actual: 8, target: 10 },
+//     socialBehaviourToEmployee: { actual: 9, target: 10 },
+//     attitudeTowardsClients: { actual: 7, target: 10 },
+//     communicationSkills: { actual: 6, target: 10 },
+//     integrityToCompany: { actual: 10, target: 10 }
+// };
+//
+// // Constructing an instance of SocialPerformance with default data
+// const socialPerformance = new SocialPerformance(defaultSocialPerformance);
+//
+// // Creating an instance of SalesPerformance using sales data
+// const salesDetails = {
+//     "HooverClean": [
+//         { clientName: "Germania GmbH", quantity: 10, rating: 3 },
+//         { clientName: "Dirk Müller GmbH", quantity: 25, rating: 3 }
+//     ],
+//     "HooverGo": [
+//         { clientName: "Telekom AG", quantity: 20, rating: 1 }
+//     ]
+// };
+//
+// // Constructing an instance of SalesPerformance with sales data
+// const salesPerformance = new SalesPerformance(salesDetails);
+//
+// // Performing the bonus calculation
+// const bonus = bonusComputation(socialPerformance, salesPerformance);
+//
+// // Printing the bonus calculation result
+// console.log("Bonus Calculation Result: ", bonus);
 

--- a/backend/src/services/employee-data-service.js
+++ b/backend/src/services/employee-data-service.js
@@ -118,4 +118,4 @@ exports.getEmployeeService = employeeDataService;
 exports.getOneEmployeeService = oneEmployeeDataService;
 exports.getEmployeeData = getEmployeeData;
 
-getEmployeeData("90133");
+

--- a/backend/src/services/order-service.js
+++ b/backend/src/services/order-service.js
@@ -134,7 +134,6 @@ async function ClientsServedBySalesman(governmentId, year) {
     const accounts = await fetchAccounts();
     const orders = await fetchOrders();
     const UID = GovIDtoUID(governmentId,accounts)
-    console.log(UID)
     const filteredOrders = orders.filter(item => {
         return item.sellerID === UID  && extractYear(item.createdAt) === Number(year)
     })
@@ -174,7 +173,7 @@ async function getOrdersEvaluation(governmentId, year){
             });
         })
     })
-    console.log(OrderEvaluation)
+    // console.log("Orderevaluation:",OrderEvaluation)
     return OrderEvaluation
 }
 

--- a/backend/src/services/performance-report-service.js
+++ b/backend/src/services/performance-report-service.js
@@ -27,7 +27,6 @@ const collectionName = 'Performance_Reports'; // Consider using snake_case for c
 async function storePerformanceRecord(db, performanceRecord) {
     try {
         const collection = db.collection(collectionName);
-        console.log(performanceRecord.calculatedBonus);
         const result = await collection.insertOne(performanceRecord);
         console.log('Performance record stored successfully.');
         return result;
@@ -131,9 +130,6 @@ async function updatePerformanceReport(db, salesManId, date, updateFields, optio
 async function storePerformanceReportInOrangeHRM(db, salesManId, date) {
     try {
         const performanceReport = (await getPerformanceReport(db, salesManId, date))[0];
-        //console.log(performanceReport);
-        //console.log("CEO: " , performanceReport.isAcceptedByCEO);
-        //console.log("HR: " , performanceReport.isAcceptedByHR);
         if (!performanceReport.isAcceptedByCEO || !performanceReport.isAcceptedByHR) {
             console.log('Performance Report is not approved by CEO or HR.');
             return;

--- a/backend/src/utils/performance-report-builder.js
+++ b/backend/src/utils/performance-report-builder.js
@@ -1,32 +1,110 @@
-const {getEmployeeService} = require('../services/employee-data-service') ;
-const {fetchProducts} = require("../services/product-service");
 const {fetchAccounts} = require("../services/account-service");
-const {fetchPositions} = require("../services/position-service");
 let {SocialPerformance} = require("../models/SocialPerformance");
-const {fetchOrders, getOrdersOfEmployee} = require("../services/order-service");
-const {SalesPerformance} = require("../models/SalesPerformance");
+const {fetchOrders, extractYear, getOrdersEvaluation} = require("../services/order-service");
+const {storePerformanceRecord} = require("../services/performance-report-service");
+
+const mongodb = require('mongodb');
+const MongoClient = mongodb.MongoClient;
+
+async function initPerformanceReports(){
+    const client = new MongoClient('mongodb+srv://oemersuezen:NDomyAOEOujuh2Cd@cluster0.in2cw.mongodb.net/');
+    await client.connect();
+    const db = client.db("performanceDB");  // Replace with your actual database name
+    await perfReportBuilder(db);
+
+}
 
 
+/**
+ * creates an Performance Reports for every SalesMan
+ *
+ * @param db
+ * @param salesmanId (the governmentId of the salesman
+ * @returns {Promise<void>}
+ */
+const defaultSocialPerformance = {
+    leadershipCompetence: { actual: 5, target: 10 },
+    opennessToEmployee: { actual: 8, target: 10 },
+    socialBehaviourToEmployee: { actual: 9, target: 10 },
+    attitudeTowardsClients: { actual: 7, target: 10 },
+    communicationSkills: { actual: 6, target: 10 },
+    integrityToCompany: { actual: 10, target: 10 }
+};
 
-//
-// /**
-//  * creates an Performance Report for ONE salesman
-//  *
-//  * @param db
-//  * @param salesmanId (the governmentId of the salesman
-//  * @returns {Promise<void>}
-//  */
-// async function perfReportBuilder(db, salesmanId) {
-//
-// }
-//
-// // function salesPerformanceBuilder(salesmanID){
-// //     const salesPerformance = new SalesPerformance();
-// //     const orders
-//     salesPerformance.addCompanyToList()
-// }
+function randomSocialPerformance(targetValue){  // the target value is the same on each criteria
+    const criteria =
+        {
+            leadershipCompetence: {},
+            opennessToEmployee: {},
+            socialBehaviourToEmployee: {},
+            attitudeTowardsClients: {},
+            communicationSkills: {},
+            integrityToCompany: {}
+        }
+    for (const key in criteria){
+        let actual = Math.random() * (targetValue + 1)  // + 1 bc the actual value can be more than the target value
+        criteria[key].target = targetValue;
+        criteria[key].actual = Number(actual.toFixed(0));
+    }
+    return new SocialPerformance((criteria))
+}
 
-// test()
+async function perfReportBuilder(db) {
+    const orders = await fetchOrders();
+    const accounts = await fetchAccounts();
+    let performanceReports = perfReportBaseBuilder(orders, accounts);
+    addOrderEvaluationAndSave(db, performanceReports)
+}
+
+function perfReportBaseBuilder(orders, accounts) {
+    let performanceReports = [];
+    let uniqueCombinations = new Set();
+    orders.forEach(order => {
+        accounts.forEach(account => {
+            // console.log(account.governmentId, extractYear(order.createdAt), account.UID )
+            // this employee did this order! The order has to be closed to be counted!
+            if (order.sellerID === account.UID && order.state === "Closed / won or next step")  {
+                const salesManId = account.governmentId.toString();
+                const date = extractYear(order.createdAt).toString();
+                const combinationKey = `${salesManId}-${date}` // Create a unique combination of salesmanid and date
+
+                if (!uniqueCombinations.has(combinationKey)){
+                    uniqueCombinations.add(combinationKey);     // This combination is now seen
+                    let performanceReport = ({
+                        salesManId,
+                        socialPerformance: randomSocialPerformance(5),
+                        date,
+                        isAcceptedByCEO: false,
+                        isAcceptedByHR: false,
+                        remark: ""
+                    })
+                    performanceReports.push(performanceReport)
+
+                }
+            }
+        })
+    })
+
+    // filter repeating combinations of year-salesman
+    performanceReports = performanceReports.filter((obj0, index, performanceReports) => {
+        return performanceReports.findIndex(obj1 => {
+            return obj0.salesManId === obj1.salesManId && obj0.date === obj1.date;
+        }) === index
+    })
+    return performanceReports;
+}
+
+
+async function addOrderEvaluationAndSave(db, performanceReports) {
+    for (const performanceReport of performanceReports) {
+        const {salesManId, date} = performanceReport;   // date is a year!
+        performanceReport.salesPerformance = await getOrdersEvaluation(salesManId, date)
+        storePerformanceRecord(db, performanceReport);
+    }
+    return performanceReports;
+}
+initPerformanceReports();
+
 
 module.exports = {
     // perfReportBuilder


### PR DESCRIPTION
- Performance Reports are now completely initializable via performance-report-builder. They are saved automatically to the database.
  - SocialPerformance values in Performance Reports are now randomly generated to a given target value.
- removed some console.logs
- some bugfixes